### PR TITLE
Move to Yarn

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,0 @@
-web: npm run deploy

--- a/README.md
+++ b/README.md
@@ -1,9 +1,17 @@
 # Kinspire Portal
 A desktop portal for the students in Kinspire's orphanages to use to access learning materials.
 
-## Prerequisites
+## 0. Setup
 
-The Portal is built with [NodeJS and NPM](https://nodejs.org).
+1. Download and install the following crucial tools for any software developer:
+    1. Plaintext editor. Millions of options, from Atom, VS Code, and Sublime to the more hardcore Vim.
+    2. Git. The version control backbone of Github.
+
+---
+
+## 1. Prerequisites
+
+The Portal is built with [NodeJS](https://nodejs.org) and [Yarn](https://yarnpkg.com/en/).
 
 ### macOS
 1. Install through [Homebrew](https://brew.sh) on a terminal window.
@@ -12,11 +20,11 @@ The Portal is built with [NodeJS and NPM](https://nodejs.org).
 $ brew install node
 ```
 
-### Windows 10+
+### Windows
 
-#### Option 1: Windows Subsystem for Linux (recommended)
+#### Option 1: Windows Subsystem for Linux (recommended for Win10)
 1. Set up WSL and Ubuntu from the Windows Store: https://docs.microsoft.com/en-us/windows/wsl/install-win10
-2. Install through Advanced Packaging Tool.
+2. Install through Advanced Packaging Tool:
 ```
 $ curl -sL https://deb.nodesource.com/setup_10.x | sudo -E bash -
 $ sudo apt-get install -y nodejs
@@ -26,34 +34,41 @@ $ sudo apt-get install -y nodejs
 1. Set up Git on Windows: https://git-scm.com/downloads
 2. Install through the website: https://nodejs.org/en/download/
 
-## Setup
+---
+
+## 2. Setup
 
 Open a terminal window (`Terminal` or `iTerm2` on Mac, `Git Bash` or `Ubuntu on Windows`) at the root of the project, and type:
 
 ```
-$ npm install
+$ yarn
 ```
 
-## Development
+---
+
+## 3. Development
 To run the Kinspire Portal in your local browser for development, run:
 ```
-$ npm start
+$ yarn start
 ```
 
 This should automatically open up http://localhost:3001 in your default browser. If not, go ahead and open it manually.
 
-## Deployment
+---
+
+## 4. Deployment
 
 ### Website
 To deploy the Kinspire Portal as a website, install [Firebase Tools](https://npmjs.com/package/firebase-tools), and then deploy the application:
 ```
-$ sudo npm i firebase-tools -g
-$ npm run deploy
+$ sudo yarn global add firebase-tools
+$ yarn deploy
 ```
 
 Note: If you're using Git Bash, remove `sudo` from the first command.
 
+### Desktop program
 To deploy the Kinspire Portal as an Electron app, run:
 ```
-$ npm run electron
+$ yarn run electron
 ```

--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@ A desktop portal for the students in Kinspire's orphanages to use to access lear
 ## 0. Setup
 
 1. Download and install the following crucial tools for any software developer:
-    1. Plaintext editor. Millions of options, from Atom, VS Code, and Sublime to the more hardcore Vim.
-    2. Git. The version control backbone of Github.
+    1. Plaintext editor. Millions of options, from [Atom](https://atom.io), [VS Code](https://code.visualstudio.com/), and [Sublime](https://www.sublimetext.com/) to the more hardcore [Vim](https://www.vim.org/) or [Emacs](https://www.gnu.org/software/emacs/).
+    2. [Git](https://git-scm.com/). The version control backbone of Github.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -3,9 +3,38 @@ A desktop portal for the students in Kinspire's orphanages to use to access lear
 
 ## 0. Setup
 
-1. Download and install the following crucial tools for any software developer:
-    1. Plaintext editor. Millions of options, from [Atom](https://atom.io), [VS Code](https://code.visualstudio.com/), and [Sublime](https://www.sublimetext.com/) to the more hardcore [Vim](https://www.vim.org/) or [Emacs](https://www.gnu.org/software/emacs/).
-    2. [Git](https://git-scm.com/). The version control backbone of Github.
+First, install a plaintext editor. There's hundreds of options, from [Atom](https://atom.io), [VS Code](https://code.visualstudio.com/), and [Sublime](https://www.sublimetext.com/) to the more hardcore [Vim](https://www.vim.org/) or [Emacs](https://www.gnu.org/software/emacs/).
+
+I would also recommend installing [GitHub Desktop](https://desktop.github.com) for those not familiar with Git on the command line.
+
+The rest of this depends on your operating system.
+
+### macOS
+
+1. **Terminal**: macOS comes with Terminal, so you should be all set. Some enthusiasts also like [iTerm2](https://www.iterm2.com/) instead.
+2. **Homebrew**: The missing package manager for macOS, this allows you to install command-line packages effortlessly. Install from https://brew.sh.
+3. **Git**: Once Homebrew is installed, run:
+
+```
+$ brew install git
+```
+
+### Windows
+
+There are two paths for developing on Windows. Windows Subsystem for Linux is a more recent development which I **strongly** recommend. It can make life a lot easier for you down the line. The other, more easy-to-pickup option is Git Bash.
+
+#### WSL
+
+1. **Terminal**: Set up WSL and Ubuntu 18 from the Windows Store: https://docs.microsoft.com/en-us/windows/wsl/install-win10
+2. **Git**: Install from a terminal window:
+
+```
+$ sudo apt update && sudo apt install -y git
+```
+
+#### Git Bash
+
+1. **Terminal**: Install Git Bash: https://git-scm.com/downloads
 
 ---
 
@@ -14,31 +43,36 @@ A desktop portal for the students in Kinspire's orphanages to use to access lear
 The Portal is built with [NodeJS](https://nodejs.org) and [Yarn](https://yarnpkg.com/en/).
 
 ### macOS
-1. Install through [Homebrew](https://brew.sh) on a terminal window.
+Install through [Homebrew](https://brew.sh) on a terminal window.
 
 ```
-$ brew install node
+$ brew install yarn
 ```
+
+This installs both Yarn and NodeJS.
 
 ### Windows
 
-#### Option 1: Windows Subsystem for Linux (recommended for Win10)
-1. Set up WSL and Ubuntu from the Windows Store: https://docs.microsoft.com/en-us/windows/wsl/install-win10
-2. Install through Advanced Packaging Tool:
+#### WSL
+Install through Advanced Packaging Tool:
+
 ```
 $ curl -sL https://deb.nodesource.com/setup_10.x | sudo -E bash -
-$ sudo apt-get install -y nodejs
+$ curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | sudo apt-key add -
+$ echo "deb https://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list
+$ sudo apt-get update && sudo apt-get install -y nodejs yarn
 ```
 
-#### Option 2: Git Bash
-1. Set up Git on Windows: https://git-scm.com/downloads
-2. Install through the website: https://nodejs.org/en/download/
+#### Git Bash
+Install through the websites:
+- https://nodejs.org/en/download/
+- https://yarnpkg.com/lang/en/docs/install/
 
 ---
 
 ## 2. Setup
 
-Open a terminal window (`Terminal` or `iTerm2` on Mac, `Git Bash` or `Ubuntu on Windows`) at the root of the project, and type:
+Open a terminal window at the root of the project, and type:
 
 ```
 $ yarn
@@ -47,12 +81,12 @@ $ yarn
 ---
 
 ## 3. Development
-To run the Kinspire Portal in your local browser for development, run:
+To run the Kinspire Portal in your local browser for development, in the same terminal window, run:
 ```
 $ yarn start
 ```
 
-This should automatically open up http://localhost:3001 in your default browser. If not, go ahead and open it manually.
+This should automatically open up http://localhost:3001 in your default browser. If not, go ahead and open it manually. **IMPORTANT**: Do not close this terminal window when developing.
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
         "start-js": "cross-env PORT=3001 react-scripts start",
         "start": "npm-run-all -p watch-css start-js",
         "test": "react-scripts test --env=jsdom",
-        "watch-css": "npm run build-css && node-sass-chokidar src/ -o src/ --watch --recursive"
+        "watch-css": "yarn run build-css && node-sass-chokidar src/ -o src/ --watch --recursive"
     },
     "devDependencies": {
         "cross-env": "^5.2.0",


### PR DESCRIPTION
NPM has historically been just absolute trash, Yarn is a much more reliable package manager. This PR changes the instructions to get set up, replaces NPM with Yarn, and also adds some more information to the README.