### PR TITLE
Remove accidental file creation that breaks Windows builds

### DIFF
--- a/src:keys:firebase-keys.json
+++ b/src:keys:firebase-keys.json
@@ -1,8 +1,0 @@
-{
-    "apiKey": "AIzaSyAwQBI6CqMLS4MZfrvTF1ZHHMcXkBXdNcM",
-    "authDomain": "kinspire-portal.firebaseapp.com",
-    "databaseURL": "https://kinspire-portal.firebaseio.com",
-    "projectId": "kinspire-portal",
-    "storageBucket": "kinspire-portal.appspot.com",
-    "messagingSenderId": "580420249743"
-  }


### PR DESCRIPTION
Windows doesn't allow `:` in filenames, while Mac does. Someone must have accidentally created this file on a Mac and committed it, which breaks the app for Windows users.